### PR TITLE
gitignore에 cypress폴더 정책 수정과 ci 커맨드를 추가했습니다.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -48,6 +48,9 @@ yarn-error.log*
 /coverage
 
 # cypress
-/cypress/videos
-/cypress/screenshots
+/cypress/*
+!/cypress/fixtures
+!/cypress/integration
+!/cypress/plugins
+!/cypress/support
 /.nyc_output

--- a/package.json
+++ b/package.json
@@ -13,7 +13,8 @@
     "e2e:headless": "start-server-and-test dev http://localhost:3000 cypress:headless",
     "test": "jest",
     "test:watch": "jest --watch",
-    "test:coverage": "jest --coverage"
+    "test:coverage": "jest --coverage",
+    "ci": "yarn lint && yarn test:coverage && yarn e2e:headless"
   },
   "dependencies": {
     "@emotion/react": "^11.4.1",


### PR DESCRIPTION
- cypress에 어떤 폴더가 어떤 상황에 자동생성되는지 잘 모르기에 기본적으로 만들어지는 폴더 4개인 `fixtures`, `integration`, `plugins`, `support` 를 제외하곤 전부 ignore 하도록 변경했습니다.
- 풀리퀘스트 할 때 마다 lint, coverage, e2e를 각각 입력하기 귀찮아서 `yarn ci` 를 입력하면 전부 확인해주도록 변경했습니다.
  - 다만 actions에는 안쓸 생각인데, 어디에서 실패했는지 한눈에 안들어올 것 같은 느낌이 들기 때문입니다.