### PR TITLE
fix: 윈도우 개발환경에서 TestMatch 경로 호환성을 조정합니다.

### DIFF
--- a/jest.config.js
+++ b/jest.config.js
@@ -8,7 +8,7 @@ module.exports = {
     '!**/.next/**',
     '!**/cypress'
   ],
-  testMatch: ['<rootDir>/__tests__/**/?(*.)+(spec|test).[jt]s?(x)'],
+  testMatch: ['**/*.test.[jt]s?(x)'],
   moduleNameMapper: {
     // Handle CSS imports (with CSS modules)
     // https://jestjs.io/docs/webpack#mocking-css-modules


### PR DESCRIPTION
Root directory could not be automatically tracked on windows env.

Tested with Mac Env. It works fine. 

Confirmed by @juunini @DavidYang2149 @bbhye1. 