### PR TITLE
config: prop-types 설정을 꺼놓습니다. 

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -27,6 +27,7 @@
   "rules": {
     "react/react-in-jsx-scope": "off",
     "react/jsx-props-no-spreading": "off",
+    "react/prop-types": "off",
     "react/jsx-filename-extension": [1, { "extensions": [".tsx", ".jsx"] }],
     "import/extensions": [
       "error",


### PR DESCRIPTION
Prop-Type 검증 옵션이 on으로 컴포넌트 Prop 타입을 확실히 체크합니다. 

프로젝트 회의 초기 Typescript로 변환할 계획이 포함되있습니다. 

Prop Type Checking은 Typescript 검증으로 대체합니다.