### PR TITLE
api/products/[id] api를 작성합니다.

### DIFF
--- a/__tests__/api/products/[id].test.js
+++ b/__tests__/api/products/[id].test.js
@@ -1,0 +1,25 @@
+import request from 'supertest';
+import http from 'http';
+
+import handler from 'pages/api/products/[id]';
+import requestListener from '__tests__/api/utils';
+
+describe('products api', () => {
+  describe('[GET] /products/1', () => {
+    const givenID = 1;
+    const givenPath = `/api/products/${givenID}`;
+
+    it('responds with json', async () => {
+      const server = http.createServer(requestListener({
+        query: {
+          id: givenID,
+        },
+        handler,
+      }));
+      const agent = await request.agent(server).get(givenPath);
+
+      expect(agent.body).toHaveProperty('id', givenID);
+      expect(agent.body).toHaveProperty('name');
+    });
+  });
+});

--- a/jest.config.js
+++ b/jest.config.js
@@ -26,6 +26,7 @@ module.exports = {
 
     // Handle module aliases
     '^@/components/(.*)$': '<rootDir>/components/$1',
+    '^__tests__/(.*)$': '<rootDir>/__tests__/$1',
     '^pages/(.*)$': '<rootDir>/pages/$1',
     '^src/(.*)$': '<rootDir>/src/$1'
   },

--- a/pages/api/products/[id].interface.ts
+++ b/pages/api/products/[id].interface.ts
@@ -7,7 +7,7 @@ import type {
   OrderLink,
 } from 'pages/api/products/[id].type';
 
-interface Data {
+interface ProductData {
   id: ID;
   image: Image;
   name: Name;
@@ -16,4 +16,4 @@ interface Data {
   orderLink: OrderLink;
 }
 
-export default Data;
+export default ProductData;

--- a/pages/api/products/[id].interface.ts
+++ b/pages/api/products/[id].interface.ts
@@ -1,0 +1,19 @@
+import type {
+  ID,
+  Image,
+  Name,
+  Price,
+  Summary,
+  OrderLink,
+} from 'pages/api/products/[id].type';
+
+interface Data {
+  id: ID;
+  image: Image;
+  name: Name;
+  price: Price;
+  summary: Summary;
+  orderLink: OrderLink;
+}
+
+export default Data;

--- a/pages/api/products/[id].mock.ts
+++ b/pages/api/products/[id].mock.ts
@@ -1,0 +1,28 @@
+export default {
+  image: {
+    src: '/image/sample_product.jpeg',
+  },
+  name: {
+    main: '샤인마토 500g',
+    sub: '설탕 없이도 달달함을 머금은 방울토마토',
+  },
+  price: {
+    original: 7_980,
+    sales: 7_580,
+    discountRate: 5,
+  },
+  summary: {
+    salesUnit: '1팩',
+    weightCapacity: '500g',
+    deliveryType: '샛별배송/택배배송',
+    originCountry: '토마토(국산)',
+    packagingType: '냉장/종이포장',
+    expirationDate: '상품 별도 표기/최소 2일이상 남은 상품으로 배송 드립니다.',
+    instructions: [
+      '- 샤인마토는 스테비오사이드 처리 가공을 하기때문에 시즌에 따라 크기와 색깔이 시즌에 따라 조금씩 차이가 날 수 있습니다. 녹색빛이 돌아도 정상이오니 안심하고 섭취 부탁드립니다.',
+      '- 꼭 냉장보관을 권장 드립니다. 절대 실온 보관하지 말아주세요.',
+      '- 신선식품으로 3% 정도의 중량오차가 발생할 수 있습니다.',
+    ],
+  },
+  orderLink: '/order',
+};

--- a/pages/api/products/[id].ts
+++ b/pages/api/products/[id].ts
@@ -1,0 +1,16 @@
+import type { NextApiRequest, NextApiResponse } from 'next';
+import type Data from 'pages/api/products/[id].interface';
+
+import mockData from 'pages/api/products/[id].mock';
+
+export default function handler(
+  req: NextApiRequest,
+  res: NextApiResponse<Data>,
+) {
+  const id = Number(req.query.id);
+
+  res.status(200).json({
+    id,
+    ...mockData,
+  });
+}

--- a/pages/api/products/[id].ts
+++ b/pages/api/products/[id].ts
@@ -1,11 +1,11 @@
 import type { NextApiRequest, NextApiResponse } from 'next';
-import type Data from 'pages/api/products/[id].interface';
+import type ProductData from 'pages/api/products/[id].interface';
 
 import mockData from 'pages/api/products/[id].mock';
 
 export default function handler(
   req: NextApiRequest,
-  res: NextApiResponse<Data>,
+  res: NextApiResponse<ProductData>,
 ) {
   const id = Number(req.query.id);
 

--- a/pages/api/products/[id].type.ts
+++ b/pages/api/products/[id].type.ts
@@ -1,0 +1,24 @@
+export type ID = number;
+export type Image = {
+  src: string;
+  alt?: string;
+};
+export type Name = {
+  main: string;
+  sub: string;
+};
+export type Price = {
+  original: number;
+  sales: number;
+  discountRate: number;
+};
+export type Summary = {
+  salesUnit: string;
+  weightCapacity: string;
+  deliveryType: string;
+  originCountry: string;
+  packagingType: string;
+  expirationDate: string;
+  instructions: string[];
+};
+export type OrderLink = string;


### PR DESCRIPTION
# Doing

- jest 경로에 __tests__ 를 추가합니다.
- `pages/api/products/[id]` api를 추가합니다.
- 위 api가 사용할 타입과 인터페이스를 정의합니다.
- 아직 백엔드와 연결된 것이 아니므로 api를 호출하면 mock data를 응답합니다.

# Why

- 인터페이스를 미리 만들어두기엔 타입스크립트가 더 적절하다고 생각했습니다.
- BFF의 용도인데 일단 여기 만들어봤습니다.

# 참고사항

![image](https://user-images.githubusercontent.com/41536271/137277306-0b43a3f4-66c8-43a0-afb0-bd674571244a.png)
