### PR TITLE
상품 리스트에서 사용되는 상품 카드 컴포넌트를 추가합니다.

### DIFF
--- a/src/products/components/Card/Card.jsx
+++ b/src/products/components/Card/Card.jsx
@@ -1,0 +1,55 @@
+import Image from 'next/image';
+
+export default function productCard({
+  id = '48934',
+  name = '샤인마토 500g',
+  discountRate = 0,
+  originalPrice = 7980,
+  salesPrice = 7980,
+  summary = '설탕 없이도 달달함을 머금은 방울토마토',
+  kurlyOnly = true,
+}) {
+  const isDiscounted = discountRate !== 0;
+
+  return (
+    <a href={`/${id}`}>
+      <Image
+        src="/image/sample_product.jpeg"
+        alt={`${name} 이미지`}
+        width={338}
+        height={435}
+      />
+      <dl>
+        <dt>
+          {name}
+        </dt>
+        {isDiscounted && (
+          <dd>
+            {discountRate}
+            %
+          </dd>
+        )}
+        <dd>
+          {salesPrice.toLocaleString()}
+          원
+        </dd>
+        {isDiscounted && (
+          <dd
+            style={{ textDecoration: 'line-through' }}
+          >
+            {originalPrice.toLocaleString()}
+            원
+          </dd>
+        )}
+        <dd>
+          {summary}
+        </dd>
+        {kurlyOnly && (
+          <dd>
+            Kurly Only
+          </dd>
+        )}
+      </dl>
+    </a>
+  );
+}


### PR DESCRIPTION
* 이 컴포넌트의 Props 는 Product 형태로 받습니다.
* 이 카드를 클릭할 경우, 해당 상품의 디테일 페이지로 이동합니다.

* 할인이 적용된 상품인 경우 다음과 같이 렌더됩니다.
<img width="478" alt="Screen Shot 2021-10-17 at 5 26 35 PM" src="https://user-images.githubusercontent.com/23205487/137619546-0e2d8486-43b1-40e6-b14b-fa754df28ea3.png">
 * 할인이 적용되지 않은 삼풍인 경우 다음과 같이 렌더됩니다
<img width="437" alt="Screen Shot 2021-10-17 at 5 27 43 PM" src="https://user-images.githubusercontent.com/23205487/137619591-0a56f306-4e62-42db-ab6e-836129c649d5.png">
. 